### PR TITLE
Add Docker setup for bot deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+dist
+data
+.env
+.env.local
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package.json tsconfig.json ./
+
+RUN npm install
+
+COPY src ./src
+
+RUN npm run build
+
+FROM node:20-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+
+RUN npm prune --omit=dev \
+    && mkdir -p data
+
+VOLUME ["/app/data"]
+
+CMD ["node", "dist/bot.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the TypeScript sources and runs the production bot
- define a docker-compose service that loads environment variables and persists the SQLite data directory
- ignore local and build artifacts from the Docker build context with a .dockerignore file

## Testing
- npm install *(fails: 403 Forbidden when fetching node-telegram-bot-api from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d53eaff51c832d85b605bf0570eec3